### PR TITLE
Fix ssh usage text

### DIFF
--- a/cmd/ssh
+++ b/cmd/ssh
@@ -14,7 +14,7 @@ Options:
   -w, --wait     wait until an ssh connection is established
   -p, --port     port to connect to (default: \"$GUEST_SSH_PORT\")
   -l, --login    the user to log in as (default: \"$GUEST_SSH_USER\")
-  -c, --comand   Execute a command and disconnect"
+  -c, --command  Execute a command and disconnect"
 
 _ssh() {
   _require_program ssh


### PR DESCRIPTION
## Summary
- correct ssh usage typo

## Testing
- `make check` *(fails: cannot find shellcheck)*

------
https://chatgpt.com/codex/tasks/task_e_6864320094548333946d13f2d2eb98e5