### PR TITLE
Fix license header in cmd/env

### DIFF
--- a/cmd/env
+++ b/cmd/env
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: GPL-3.0-or-late
+# SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
 #
 # Written by Joel Granados <joel.granados@kernel.org>


### PR DESCRIPTION
## Summary
- correct the SPDX identifier for `cmd/env`

## Testing
- `make check` *(fails: cannot find shellcheck)*

------
https://chatgpt.com/codex/tasks/task_e_686431fe00948333be461014c2be2c98