### PR TITLE
Fix README env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ running.
         ```
     2. Activate `vmctl` with `env` for your current shell
         ```
-        $ ./vmctl env --confdir $HOME/vms
+        $ ./vmctl env --bootstrap $HOME/vms --verbose
+        $ ./vmctl env
         $ vmctl --help
         $ vmctl -c CONFIG <command>
         ```


### PR DESCRIPTION
## Summary
- update `env` example to reflect `--bootstrap` and `--verbose` options

## Testing
- `make check` *(fails: cannot find shellcheck)*

------
https://chatgpt.com/codex/tasks/task_e_686431f99f908333a27cf04debbd3543