### PR TITLE
Fix console shebang

### DIFF
--- a/cmd/console
+++ b/cmd/console
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash/
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
 #


### PR DESCRIPTION
## Summary
- ensure `cmd/console` uses the correct bash shebang

## Testing
- `make check` *(fails: cannot find shellcheck)*

------
https://chatgpt.com/codex/tasks/task_e_686431ecc23083339ff27a06304b5067